### PR TITLE
Custom Menu Input Scanner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.academiadecodigo.bootcamp</groupId>
     <artifactId>prompt-view</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
 
     <dependencies>
 

--- a/src/main/java/org/academiadecodigo/bootcamp/scanners/menu/CustomMenuInputScanner.java
+++ b/src/main/java/org/academiadecodigo/bootcamp/scanners/menu/CustomMenuInputScanner.java
@@ -1,0 +1,35 @@
+package org.academiadecodigo.bootcamp.scanners.menu;
+
+import org.academiadecodigo.bootcamp.scanners.integer.IntegerSetInputScanner;
+import java.util.Map;
+
+public class CustomMenuInputScanner extends IntegerSetInputScanner {
+    private Map<Integer,String> optionMap;
+
+    public CustomMenuInputScanner(Map<Integer,String> optionMap) {
+        super(optionMap.keySet());
+        this.optionMap = optionMap;
+        super.setMessage(buildMenu(getMessage()));
+    }
+
+    @Override
+    public void setMessage(String message) {
+        super.setMessage(buildMenu(message));
+    }
+
+    private String buildMenu(String message) {
+
+        StringBuilder menuBuilder = new StringBuilder("\n");
+        menuBuilder.append(message);
+        menuBuilder.append("\n");
+
+        for(Integer i: optionMap.keySet()) {
+            menuBuilder.append("\n");
+            menuBuilder.append(i + " - " + optionMap.get(i));
+        }
+
+        menuBuilder.append("\n> ");
+        return menuBuilder.toString();
+
+    }
+}

--- a/src/main/java/org/academiadecodigo/bootcamp/scanners/menu/CustomMenuInputScanner.java
+++ b/src/main/java/org/academiadecodigo/bootcamp/scanners/menu/CustomMenuInputScanner.java
@@ -2,13 +2,14 @@ package org.academiadecodigo.bootcamp.scanners.menu;
 
 import org.academiadecodigo.bootcamp.scanners.integer.IntegerSetInputScanner;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class CustomMenuInputScanner extends IntegerSetInputScanner {
     private Map<Integer,String> optionMap;
 
     public CustomMenuInputScanner(Map<Integer,String> optionMap) {
         super(optionMap.keySet());
-        this.optionMap = optionMap;
+        this.optionMap = new TreeMap<>(optionMap);
         super.setMessage(buildMenu(getMessage()));
     }
 
@@ -25,7 +26,7 @@ public class CustomMenuInputScanner extends IntegerSetInputScanner {
 
         for(Integer i: optionMap.keySet()) {
             menuBuilder.append("\n");
-            menuBuilder.append(i + " - " + optionMap.get(i));
+            menuBuilder.append(i).append(" - ").append(optionMap.get(i));
         }
 
         menuBuilder.append("\n> ");

--- a/src/test/java/examples/menu/CustomMenuInputScannerTest.java
+++ b/src/test/java/examples/menu/CustomMenuInputScannerTest.java
@@ -1,0 +1,23 @@
+package examples.menu;
+
+import org.academiadecodigo.bootcamp.Prompt;
+import org.academiadecodigo.bootcamp.scanners.menu.CustomMenuInputScanner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomMenuInputScannerTest {
+    public static void main(String[] args) {
+        Prompt prompt = new Prompt(System.in,System.out);
+
+        Map<Integer,String> options = new HashMap<>();
+        options.put(5,"Bahia");
+        options.put(30,"João");
+        options.put(2,"Tiago");
+
+        CustomMenuInputScanner scanner = new CustomMenuInputScanner(options);
+        scanner.setMessage("Choose someone:");
+
+        System.out.println(prompt.getUserInput(scanner));
+    }
+}


### PR DESCRIPTION
Created a new Custom Menu Input Scanner. This scanner is different from the MenuInputScanner in the sense that you can now choose what numbers appear as options.
This came from the need to have a menu that would display the options not as the standard 1 to n, but as a set of pre-determined numbers. For example, to ask a customer to which of his accounts he wants to perform an action. The account numbers will probably be some numbers that are not sequencial.